### PR TITLE
fix(scripts): Make build script robust and fix tagging bug

### DIFF
--- a/scripts/build-images.sh
+++ b/scripts/build-images.sh
@@ -3,48 +3,56 @@
 # Exit immediately if a command exits with a non-zero status
 set -e
 
+# --- Determine script location and repository root ---
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+REPO_ROOT="$SCRIPT_DIR/.."
+
+# --- Configuration ---
 # Set your Docker Hub username
 DOCKER_USER="devdenise"
+# Get the short Git commit hash to use as a unique tag
+# We run the git command from the repo root to be safe
+GIT_HASH=$(cd "$REPO_ROOT" && git rev-parse --short HEAD)
 
+# --- Pre-flight Checks ---
+# Check if Git hash was found
+if [ -z "$GIT_HASH" ]; then
+  echo "Error: Could not get Git hash. Are you in a git repository?"
+  exit 1
+fi
+
+# Check for Docker Hub token
 if [ -z "$DOCKER_TOKEN" ]; then
   echo "Error: DOCKER_TOKEN environment variable not set."
   exit 1
 fi
 
-echo "$DOCKER_TOKEN" | docker login -u "devdenise" --password-stdin
+# --- Login to Docker Hub ---
+echo "Logging in to Docker Hub..."
+echo "$DOCKER_TOKEN" | docker login -u "$DOCKER_USER" --password-stdin
 
-# Define image names and tags
-BACKEND_IMAGE="$DOCKER_USER/financeplatform-backend:latest"
-FRONTEND_IMAGE="$DOCKER_USER/financeplatform-frontend:latest"
+# --- Define Image Names ---
+BACKEND_IMAGE_NAME="$DOCKER_USER/financeplatform-backend"
+FRONTEND_IMAGE_NAME="$DOCKER_USER/financeplatform-frontend"
 
-# Check if Dockerfiles have changed (optional - you might want to remove this check for now)
-if git diff --quiet Dockerfile ../backend/Dockerfile ../frontend/Dockerfile; then
-  echo "No changes detected in Dockerfiles. Skipping image build."
-  exit 0
-fi
+# --- Build and Push Backend Image ---
+echo "Building backend image: $BACKEND_IMAGE_NAME:$GIT_HASH"
+# Use the repo root as the build context (.) and specify the Dockerfile path with -f
+docker build -t "$BACKEND_IMAGE_NAME:$GIT_HASH" -f "$REPO_ROOT/backend/Dockerfile" "$REPO_ROOT"
+docker tag "$BACKEND_IMAGE_NAME:$GIT_HASH" "$BACKEND_IMAGE_NAME:latest"
 
-# Build backend image
-echo "Building backend image..."
-cd ../backend
-if [[ ! -f "package.json" ]]; then
-  echo "Error: package.json not found in backend directory"
-  exit 1
-fi
+echo "Pushing backend tags ($GIT_HASH and latest)..."
+docker push "$BACKEND_IMAGE_NAME:$GIT_HASH"
+docker push "$BACKEND_IMAGE_NAME:latest"
 
-docker build -t $BACKEND_IMAGE .
-echo "Pushing backend image..."
-docker push $BACKEND_IMAGE
+# --- Build and Push Frontend Image ---
+echo "Building frontend image: $FRONTEND_IMAGE_NAME:$GIT_HASH"
+# Use the repo root as the build context (.) and specify the Dockerfile path with -f
+docker build -t "$FRONTEND_IMAGE_NAME:$GIT_HASH" -f "$REPO_ROOT/frontend/Dockerfile" "$REPO_ROOT"
+docker tag "$FRONTEND_IMAGE_NAME:$GIT_HASH" "$FRONTEND_IMAGE_NAME:latest"
 
-# Build frontend image
-echo "Building frontend image..."
-cd ../frontend
-if [[ ! -f "package.json" ]]; then
-  echo "Error: package.json not found in frontend directory"
-  exit 1
-fi
+echo "Pushing frontend tags ($GIT_HASH and latest)..."
+docker push "$FRONTEND_IMAGE_NAME:$GIT_HASH"
+docker push "$FRONTEND_IMAGE_NAME:latest"
 
-docker build -t $FRONTEND_IMAGE .
-echo "Pushing frontend image..."
-docker push $FRONTEND_IMAGE
-
-echo "Docker images built and pushed successfully."
+echo "Docker images built and pushed successfully with tag '$GIT_HASH' and 'latest'."


### PR DESCRIPTION
This commit improves the `scripts/build-images.sh` script in two ways:

1.  **Execution Path:** The script is now runnable from any directory. It programmatically determines the repository root and uses absolute paths for the build context and Dockerfile locations. This resolves the `could not find backend` error when running the script from a subdirectory.

2.  **Tagging Bug:** Fixed a copy-paste error where the backend image name was being used to tag the frontend image. Both images are now tagged correctly.