### PR TITLE
fix(scripts): Set correct Docker build context

### DIFF
--- a/scripts/build-images.sh
+++ b/scripts/build-images.sh
@@ -37,8 +37,8 @@ FRONTEND_IMAGE_NAME="$DOCKER_USER/financeplatform-frontend"
 
 # --- Build and Push Backend Image ---
 echo "Building backend image: $BACKEND_IMAGE_NAME:$GIT_HASH"
-# Use the repo root as the build context (.) and specify the Dockerfile path with -f
-docker build -t "$BACKEND_IMAGE_NAME:$GIT_HASH" -f "$REPO_ROOT/backend/Dockerfile" "$REPO_ROOT"
+# Set the build context to the 'backend' directory
+docker build -t "$BACKEND_IMAGE_NAME:$GIT_HASH" -f "$REPO_ROOT/backend/Dockerfile" "$REPO_ROOT/backend"
 docker tag "$BACKEND_IMAGE_NAME:$GIT_HASH" "$BACKEND_IMAGE_NAME:latest"
 
 echo "Pushing backend tags ($GIT_HASH and latest)..."
@@ -47,8 +47,8 @@ docker push "$BACKEND_IMAGE_NAME:latest"
 
 # --- Build and Push Frontend Image ---
 echo "Building frontend image: $FRONTEND_IMAGE_NAME:$GIT_HASH"
-# Use the repo root as the build context (.) and specify the Dockerfile path with -f
-docker build -t "$FRONTEND_IMAGE_NAME:$GIT_HASH" -f "$REPO_ROOT/frontend/Dockerfile" "$REPO_ROOT"
+# Set the build context to the 'frontend' directory
+docker build -t "$FRONTEND_IMAGE_NAME:$GIT_HASH" -f "$REPO_ROOT/frontend/Dockerfile" "$REPO_ROOT/frontend"
 docker tag "$FRONTEND_IMAGE_NAME:$GIT_HASH" "$FRONTEND_IMAGE_NAME:latest"
 
 echo "Pushing frontend tags ($GIT_HASH and latest)..."


### PR DESCRIPTION
The previous version of the build script incorrectly used the repository root as the build context for both frontend and backend builds. This caused errors because the Dockerfiles expect their own directories as the build context to find files like `package.json`.

This commit corrects the `docker build` commands in `scripts/build-images.sh` to use the correct build context for each image (`backend/` for the backend, `frontend/` for the frontend). This resolves the `"/yarn.lock": not found` error during the build process.